### PR TITLE
Do not install a channel and VM are not required anymore 

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,8 @@ let
   inherit (pkgs) stdenv;
   inherit (pkgs.lib) concatStringsSep genList;
 
-  channel = "nixos-${builtins.readFile "${pkgs.path}/.version"}";
+  channel = builtins.replaceStrings ["\n"] [""]
+    "nixos-${builtins.readFile "${pkgs.path}/.version"}";
 
   channelUrl = "https://github.com/NixOS/nixpkgs-channels/archive/${channel}.tar.gz";
 


### PR DESCRIPTION
- The channel takes about 130MB and it is not required for all use
  cases. The channel URL is still configured, so a user that wants to
  use the channel just have to first run nix-channel --update.

- `runAsRoot` build the derivation in a VM while this is not
  required. With `extraCommands`, files are created as user and their
  uid/gid are set to 0 by `tar`.

This commit also fixes gcroots issues. Now, all paths are registered as
gcroots. So nix-store --gc doesn't clean anything.

Test: I manually run the container and be able to 
- `nix-store --gc`
- `nix-channel --update`
- `nix-env -i hello`
- `hello`